### PR TITLE
sepolicy: Resolve turbo_adapter denial

### DIFF
--- a/common/dynamic/hwservice.te
+++ b/common/dynamic/hwservice.te
@@ -5,3 +5,6 @@ type hal_lineage_livedisplay_hwservice, hwservice_manager_type;
 type hal_lineage_powershare_hwservice, hwservice_manager_type;
 type hal_lineage_touch_hwservice, hwservice_manager_type;
 type hal_lineage_trust_hwservice, hwservice_manager_type;
+
+# TurboAdapter
+type hal_turbo_adapter_hwservice, hwservice_manager_type;

--- a/common/dynamic/hwservice_contexts
+++ b/common/dynamic/hwservice_contexts
@@ -1,4 +1,5 @@
 motorola.hardware.health::IMotHealth                                    u:object_r:hal_health_hwservice:s0
+vendor.google.google_battery::IGoogleBattery                            u:object_r:hal_turbo_adapter_hwservice:s0
 vendor.lineage.biometrics.fingerprint.inscreen::IFingerprintInscreen    u:object_r:hal_lineage_fod_hwservice:s0
 vendor.lineage.camera.motor::ICameraMotor                               u:object_r:hal_lineage_camera_motor_hwservice:s0
 vendor.lineage.fastcharge::IFastCharge                                  u:object_r:hal_lineage_fastcharge_hwservice:s0

--- a/common/dynamic/turbo_adapter.te
+++ b/common/dynamic/turbo_adapter.te
@@ -9,5 +9,8 @@ app_domain(turbo_adapter)
 # To use ServiceManager
 allow turbo_adapter app_api_service:service_manager find;
 
+allow turbo_adapter hal_turbo_adapter_hwservice:hwservice_manager find;
+
 # To find and call hal_power_default so turbo can obtain the service extension (IPowerExt)
 hal_client_domain(turbo_adapter, hal_power)
+


### PR DESCRIPTION
* E SELinux : avc:  denied  { find } for interface=vendor.google.google_battery::IGoogleBattery sid=u:r:turbo_adapter:s0:c226,c256,c512,c768 pid=10183 scontext=u:r:turbo_adapter:s0:c226,c256,c512,c768 tcontext=u:object_r:default_android_hwservice:s0 tclass=hwservice_manager permissive=0